### PR TITLE
feat(be): ApiV1NoticeController.kt 추가.

### DIFF
--- a/backend/src/main/kotlin/com/back/domain/notices/controller/ApiV1NoticeController.kt
+++ b/backend/src/main/kotlin/com/back/domain/notices/controller/ApiV1NoticeController.kt
@@ -1,0 +1,113 @@
+package com.back.domain.notices.controller
+
+import com.back.domain.notices.dto.CreateNoticeRequestDto
+import com.back.domain.notices.dto.DeleteNoticeRequestDto
+import com.back.domain.notices.dto.NoticeResponseDto
+import com.back.domain.notices.dto.UpdateNoticeRequestDto
+import com.back.domain.notices.service.NoticeService
+import com.back.global.rsData.RsData
+import com.back.global.security.CustomMemberDetails
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/notices")
+@Tag(name = "NoticeController", description = "공지사항 컨트롤러")
+class ApiV1NoticeController (
+    private val noticeService: NoticeService,
+) {
+   @GetMapping
+   @Operation(summary = "공지사항 전체 조회 (검색 기능 + 페이징 포함")
+   fun getAllNotices(
+       @RequestParam(required = false) search: String,
+       @RequestParam(required = false) page: Int,
+       @RequestParam(required = false) pageSize: Int,
+   ): ResponseEntity<RsData<Page<NoticeResponseDto>>> {
+       val pageable = PageRequest.of(page, pageSize)
+       val notices = noticeService.getAllNotices(search, pageable)
+       return ResponseEntity(
+           RsData(
+               "200-1",
+               "공지사항 목록을 조회했습니다.",
+               notices
+           ),
+           HttpStatus.OK
+       )
+   }
+
+    @GetMapping("{id}")
+    @Operation(summary = "공지사항 단건 조회")
+    fun getNotice(
+        @PathVariable id: Int
+    ) : ResponseEntity<RsData<NoticeResponseDto>> {
+        val notice = noticeService.getNoticeById(id)
+        return ResponseEntity(
+            RsData(
+                "200-1",
+                "공지사항을 조회했습니다.",
+                notice
+            ),
+            HttpStatus.OK
+        )
+    }
+
+    @PostMapping
+    @Operation(summary = "공지사항 생성")
+    fun createNotice(
+        @AuthenticationPrincipal memberDetails: CustomMemberDetails,
+        @Valid @RequestBody dto: CreateNoticeRequestDto
+    ) : ResponseEntity<RsData<NoticeResponseDto>> {
+        val notice = noticeService.createNotice(dto, memberDetails.getMember())
+        return ResponseEntity(
+            RsData(
+                "200-1",
+                "공지사항이 생성되었습니다.",
+                notice
+            ),
+            HttpStatus.OK
+        )
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "공지사항 수정")
+    fun updateNotice(
+        @AuthenticationPrincipal memberDetails: CustomMemberDetails,
+        @PathVariable id: Int,
+        @Valid @RequestBody dto: UpdateNoticeRequestDto
+    ) : ResponseEntity<RsData<NoticeResponseDto>> {
+        val notice = noticeService.updateNotice(id, dto, memberDetails.getMember())
+        return ResponseEntity(
+            RsData(
+                "200-1",
+                "공지사항이 수정되었습니다.",
+                notice
+            ),
+            HttpStatus.OK
+        )
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "공지사항 삭제")
+    fun deleteNotice(
+        @AuthenticationPrincipal memberDetails: CustomMemberDetails,
+        @PathVariable id: Int,
+    ) : ResponseEntity<RsData<NoticeResponseDto>> {
+        val notice = noticeService.deleteNotice(DeleteNoticeRequestDto(id), memberDetails.getMember())
+        val noticeDto = NoticeResponseDto(notice)
+        return ResponseEntity(
+            RsData(
+                "200-1",
+                "공지사항이 삭제되었습니다.",
+                noticeDto
+            ),
+            HttpStatus.OK
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/back/domain/notices/service/NoticeService.kt
+++ b/backend/src/main/kotlin/com/back/domain/notices/service/NoticeService.kt
@@ -60,11 +60,12 @@ class NoticeService (
         return NoticeResponseDto.from(updatedNotice)
     }
 
-    fun deleteNotice(dto: DeleteNoticeRequestDto, member: Member) {
+    fun deleteNotice(dto: DeleteNoticeRequestDto, member: Member) : Notice {
         require(member.role == MemberRole.ADMIN) { "관리자만 공지사항을 삭제할 수 있습니다." }
         val notice: Notice = noticeRepository.findById(dto.id).orElseThrow {
             IllegalArgumentException("공지사항을 찾을 수 없습니다.")
         }
         noticeRepository.delete(notice)
+        return notice
     }
 }

--- a/backend/src/main/kotlin/com/back/domain/transactions/controller/ApiV1AccountTransactionController.kt
+++ b/backend/src/main/kotlin/com/back/domain/transactions/controller/ApiV1AccountTransactionController.kt
@@ -1,0 +1,11 @@
+package com.back.domain.transactions.controller
+
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/transactions/account")
+@Tag(name = "NoticeController", description = "계좌 거래 컨트롤러")
+class ApiV1AccountTransactionController {
+}

--- a/backend/src/main/kotlin/com/back/domain/transactions/controller/ApiV1TransactionController.kt
+++ b/backend/src/main/kotlin/com/back/domain/transactions/controller/ApiV1TransactionController.kt
@@ -6,12 +6,14 @@ import com.back.domain.transactions.dto.UpdateTransactionRequestDto
 import com.back.domain.transactions.service.TransactionService
 import com.back.global.rsData.RsData
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/transactions/asset")
+@Tag(name = "NoticeController", description = "자산 거래 컨트롤러")
 class ApiV1TransactionController (
     private val transactionService: TransactionService,
 ) {


### PR DESCRIPTION
- Notice 도메인의 REST API를 위한 ApiV1NoticeController 클래스를 추가 했습니다.
- API 구조에 맞게 Service의 일부 코드를 수정 했습니다.
- ApiV1AccountTransactionController.kt init => 차후 Account 도메인 도입 이후 작성.